### PR TITLE
Fixes #23 Don't use esc_url on original image src

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -283,7 +283,7 @@ class Image
 
         $placeholder_atts = preg_replace('@\ssrc\s*=\s*(\'|")(?<src>.*)\1@iUs', ' src=$1' . $this->getPlaceholder($width, $height) . '$1', $image['atts']);
 
-        $image_lazyload = str_replace($image['atts'], $placeholder_atts . ' data-lazy-src="' . esc_url($image['src']) . '"', $image[0]);
+        $image_lazyload = str_replace($image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image[0]);
 
         /**
          * Filter the LazyLoad HTML output

--- a/tests/Unit/Image/TestLazyloadImages.php
+++ b/tests/Unit/Image/TestLazyloadImages.php
@@ -69,7 +69,6 @@ class TestLazyloadImages extends TestCase
      */
     public function testShouldReturnImagesLazyloaded()
     {
-        Functions\when('esc_url')->returnArg();
         Functions\when('absint')->alias(function ($value) {
             return abs(intval($value));
         });


### PR DESCRIPTION
`esc_url()` is removing inline base64 image, notably used by Polylang for displaying the flags