### PR TITLE
Fix #2177 - Replace YouTube iframe with preview image is not working when using relative protocol

### DIFF
--- a/src/Iframe.php
+++ b/src/Iframe.php
@@ -227,7 +227,7 @@ class Iframe
      */
     public function cleanYoutubeUrl ( $url ) {
         $parsed_url = wp_parse_url( $url, -1 );
-        $scheme     = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';
+        $scheme     = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '//';
         $host       = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
         $path       = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
 

--- a/tests/Integration/contentProvider/Iframe/iframelazyloaded.html
+++ b/tests/Integration/contentProvider/Iframe/iframelazyloaded.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,7 +213,9 @@ img.emoji {
 <iframe loading="lazy" width="1140" height="641" src="about:blank" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen data-rocket-lazyload="fitvidscompatible" data-lazy-src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed"></iframe><noscript><iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
 </div></figure>
 
-
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<iframe loading="lazy" width="1140" height="641" src="about:blank" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen data-rocket-lazyload="fitvidscompatible" data-lazy-src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed"></iframe><noscript><iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
+</div></figure>
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
 
@@ -271,7 +273,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;

--- a/tests/Integration/contentProvider/Iframe/youtube.html
+++ b/tests/Integration/contentProvider/Iframe/youtube.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,7 +213,9 @@ img.emoji {
 <iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div></figure>
 
-
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div></figure>
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
 
@@ -271,7 +273,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;

--- a/tests/Integration/contentProvider/Iframe/youtubelazyloaded.html
+++ b/tests/Integration/contentProvider/Iframe/youtubelazyloaded.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,7 +213,9 @@ img.emoji {
 <div class="rll-youtube-player" data-src="https://www.youtube.com/embed/Yirc35yIjfc" data-id="Yirc35yIjfc" data-query="feature=oembed"></div><noscript><iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
 </div></figure>
 
-
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<div class="rll-youtube-player" data-src="//www.youtube.com/embed/Yirc35yIjfc" data-id="Yirc35yIjfc" data-query="feature=oembed"></div><noscript><iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
+</div></figure>
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
 
@@ -271,7 +273,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;

--- a/tests/Unit/fixtures/Iframe/iframelazyloaded.html
+++ b/tests/Unit/fixtures/Iframe/iframelazyloaded.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,6 +213,9 @@ img.emoji {
 <iframe loading="lazy" width="1140" height="641" src="about:blank" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen data-rocket-lazyload="fitvidscompatible" data-lazy-src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed"></iframe><noscript><iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
 </div></figure>
 
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<iframe loading="lazy" width="1140" height="641" src="about:blank" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen data-rocket-lazyload="fitvidscompatible" data-lazy-src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed"></iframe><noscript><iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
+</div></figure>
 
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
@@ -271,7 +274,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;

--- a/tests/Unit/fixtures/Iframe/youtube.html
+++ b/tests/Unit/fixtures/Iframe/youtube.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,6 +213,9 @@ img.emoji {
 <iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div></figure>
 
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div></figure>
 
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
@@ -271,7 +274,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;

--- a/tests/Unit/fixtures/Iframe/youtubelazyloaded.html
+++ b/tests/Unit/fixtures/Iframe/youtubelazyloaded.html
@@ -10,7 +10,7 @@
 		<script type="text/javascript">
 		var ajaxurl = 'http://wordpress.test/wp-admin/admin-ajax.php';
 		</script>
-		
+
 <!-- This site is optimized with the Yoast SEO plugin v9.6 - https://yoast.com/wordpress/plugins/seo/ -->
 <meta name="description" content="WP Test en Français est un ensemble de données de test pour mesurer l&#039;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress."/>
 <link rel="canonical" href="http://wordpress.test/a-propos/" />
@@ -71,7 +71,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1149' />
@@ -80,7 +80,7 @@ img.emoji {
         <style>
             a { color: #0000FF; }
         </style>
-        	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
+            <noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
 	<link rel="amphtml" href="http://wordpress.test/a-propos/?amp"><style type="text/css" media="print">#wpadminbar { display:none; }</style>
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
@@ -200,7 +200,7 @@ img.emoji {
             <p>Posted by <span class="vcard author"><span class="fn">FX Bénard</span></span> on <span class="updated">15 March 2013</span></p>
         </aside>
         <div class="entry-content">
-            
+
 <p><a href="http://wptest.fxbenard.com/">WP Test en Français</a> est un ensemble fantastiquement exhaustif de données de test pour mesurer l&#8217;intégrité et les fonctionnalités de vos extensions et de vos thèmes WordPress.</p>
 
 
@@ -213,6 +213,9 @@ img.emoji {
 <div class="rll-youtube-player" data-src="https://www.youtube.com/embed/Yirc35yIjfc" data-id="Yirc35yIjfc" data-query="feature=oembed"></div><noscript><iframe width="1140" height="641" src="https://www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
 </div></figure>
 
+<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+<div class="rll-youtube-player" data-src="//www.youtube.com/embed/Yirc35yIjfc" data-id="Yirc35yIjfc" data-query="feature=oembed"></div><noscript><iframe width="1140" height="641" src="//www.youtube.com/embed/Yirc35yIjfc?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></noscript>
+</div></figure>
 
 
 <p>La base de ces tests est issue des données du codex <a rel="noreferrer noopener" href="http://codex.wordpress.org/Theme_Unit_Test" target="_blank">Theme Unit Test</a> de WordPress. Ajoutez y les enseignements tirés de plusieurs années d&#8217;utilisation, de création de thèmes et d&#8217;extensions, et vous obtenez <strong>un puissant cocktail de simulation de contenu d&#8217;utilisateur.</strong></p>
@@ -271,7 +274,7 @@ var wc_cart_fragments_params = {"ajax_url":"\/wp-admin\/admin-ajax.php","wc_ajax
 				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
 						request = true;
-		
+
 				b[c] = b[c].replace( rcs, ' ' );
 				// The customizer requires postMessage and CORS (if the site is cross domain)
 				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;


### PR DESCRIPTION
When Replace YouTube iframe with preview image is active, and a Youtube video is added using a relative URL, our lazyload rewrite strips the // and it causes a 404 error when the video is played.

So, this kind of iframe:

```html
<iframe src="//www.youtube.com/embed/vWxHWLqO8yc" allowfullscreen="1"></iframe>
```

When the user tries to play the youtube video, outputs like this, causing a 404 error:

```
<iframe src="www.youtube.com/embed/vWxHWLqO8yc?autoplay=1" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"></iframe>
```

Related ticket:
https://secure.helpscout.net/conversation/1029194499/136176?folderId=2683093

Reference Issue #57 