### PR TITLE
2.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 branches:
   only:
   - master
+  - develop
 cache:
   directories:
   - vendor

--- a/src/Iframe.php
+++ b/src/Iframe.php
@@ -107,6 +107,8 @@ class Iframe
                 'data-no-lazy=',
                 'recaptcha/api/fallback',
                 'loading="eager"',
+                'data-skip-lazy',
+                'skip-lazy',
             ]
         );
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -259,6 +259,8 @@ class Image
                 'data-height-percentage',
                 'data-large_image',
                 'avia-bg-style-fixed',
+                'data-skip-lazy',
+                'skip-lazy',
             ]
         );
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -92,10 +92,13 @@ class Image
     private function addLazyClass($element)
     {
         if (preg_match('#class=["\']?(?<classes>[^"\'>]*)["\']?#is', $element, $class)) {
-            $classes = str_replace($class['classes'], $class['classes'] . ' rocket-lazyload', $class[0]);
-            $element = str_replace($class[0], $classes, $element);
+            if (empty($class['classes'])) {
+                return str_replace($class[0], 'class="rocket-lazyload"', $element);
+            }
 
-            return $element;
+            $classes = str_replace($class['classes'], $class['classes'] . ' rocket-lazyload', $class[0]);
+
+            return str_replace($class[0], $classes, $element);
         }
 
         return preg_replace('#<(img|div|section|li|span)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element);

--- a/tests/Unit/Iframe/TestIsIframeExcluded.php
+++ b/tests/Unit/Iframe/TestIsIframeExcluded.php
@@ -88,6 +88,20 @@ class TestIsIframeExcluded extends TestCase
                     'width="560" height="315" data-no-lazy="1" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen',
                 ],
             ],
+            [
+                [
+                    '<iframe width="560" height="315" data-skip-lazy="1" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+                    'width="560" height="315" data-skip-lazy="1" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen',
+                    'width="560" height="315" data-skip-lazy="1" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen',
+                ],
+            ],
+            [
+                [
+                    '<iframe width="560" height="315" class="skip-lazy" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+                    'width="560" height="315" class="skip-lazy" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen',
+                    'width="560" height="315" class="skip-lazy" src="https://www.youtube.com/embed/Y7pVUaPJeg8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen',
+                ],
+            ],
         ];
     }
 

--- a/tests/Unit/Image/TestExcluded.php
+++ b/tests/Unit/Image/TestExcluded.php
@@ -72,6 +72,8 @@ class TestExcluded extends TestCase
             'data-height-percentage',
             'data-large_image',
             'avia-bg-style-fixed',
+            'data-skip-lazy',
+            'skip-lazy'
 
         ];
 

--- a/tests/Unit/Image/TestIsExcluded.php
+++ b/tests/Unit/Image/TestIsExcluded.php
@@ -81,6 +81,8 @@ class TestIsExcluded extends TestCase
             'data-height-percentage',
             'data-large_image',
             'avia-bg-style-fixed',
+            'data-skip-lazy',
+            'skip-lazy',
         ];
 
         return [
@@ -164,6 +166,14 @@ class TestIsExcluded extends TestCase
                 'class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"',
                 $excluded_attributes,
             ],
+            [
+                'class="skip-lazy" style="background-image:url(example.jpg)" data-section-bg="repeat"',
+                $excluded_attributes,
+            ],
+            [
+                'data-skip-lazy="1" style="background-image:url(example.jpg)" data-section-bg="repeat"',
+                $excluded_attributes,
+            ],
         ];
     }
 
@@ -227,6 +237,8 @@ class TestIsExcluded extends TestCase
             'data-height-percentage',
             'data-large_image',
             'avia-bg-style-fixed',
+            'data-skip-lazy',
+            'skip-lazy',
         ];
 
         return [

--- a/tests/Unit/fixtures/Image/bgimages.html
+++ b/tests/Unit/fixtures/Image/bgimages.html
@@ -97,6 +97,7 @@ img.emoji {
 <div style="background-image   :    url(   test.jpg   )   "></div>
 <div style="background-image:url(test.jpg)"></div>
 <div class="test" style="background-image:url('test.jpg')"></div>
+<div class="" style="background-image:url('test.jpg')"></div>
 <div style    =   'background-image:url("test.jpg")'></div>
 <div style='background-image:url("test.jpg"); color:#000'></div>
 <div data-test="bla" style='background-image:url("test.jpg")    ; color:#000'></div>

--- a/tests/Unit/fixtures/Image/bgimageslazyloaded.html
+++ b/tests/Unit/fixtures/Image/bgimageslazyloaded.html
@@ -97,6 +97,7 @@ img.emoji {
 <div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
 <div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
 <div data-bg="url(test.jpg)" class="test rocket-lazyload" style=""></div>
+<div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
 <div data-bg="url(test.jpg)" class="rocket-lazyload" style    =   ''></div>
 <div data-bg="url(test.jpg)" class="rocket-lazyload" style=' color:#000'></div>
 <div data-bg="url(test.jpg)" class="rocket-lazyload" data-test="bla" style=' color:#000'></div>


### PR DESCRIPTION
- Enhancement: Add `data-skip-lazy` and `skip-lazy` class to exclusions list as part of the interoperability initiative between lazyload plugins (#58)
- Bugfix: Correctly add the `rocket-lazyload` class when class attribute is empty on an element with a background image (#60)