### PR TITLE
Allow <figure> tags to lazyload background images

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -53,7 +53,7 @@ class Image
      */
     public function lazyloadBackgroundImages($html, $buffer)
     {
-        if (! preg_match_all('#<(?<tag>div|section|span|li)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER)) {
+        if (! preg_match_all('#<(?<tag>div|figure|section|span|li)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER)) {
             return $html;
         }
 
@@ -101,7 +101,7 @@ class Image
             return str_replace($class[0], $classes, $element);
         }
 
-        return preg_replace('#<(img|div|section|li|span)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element);
+        return preg_replace('#<(img|div|figure|section|li|span)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element);
     }
 
     /**

--- a/tests/Unit/fixtures/Image/bgimages.html
+++ b/tests/Unit/fixtures/Image/bgimages.html
@@ -68,7 +68,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1147' />
@@ -105,6 +105,7 @@ img.emoji {
 <div class="fusion-fullwidth fullwidth-box fusion-parallax-none nonhundred-percent-fullwidth non-hundred-percent-height-scrolling" style="background-color: #ffffff;background-image: url(http://mega.wp-rocket.me/avada/wp-content/uploads/2014/11/review_bkgd321-compressor.jpg);background-position: center center;background-repeat: no-repeat;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover;"></div>
 <div style='background-image:url(https://concretegenius.ca/wp-content/uploads/2019/02/Overhead-17-Korova-East.png);background-repeat:no-repeat;background-position:center;background-attachment:;border-top-width:px;border-top-style:solid;border-top-color:;border-bottom-width:px;border-bottom-style:solid;border-bottom-color:;'  class="row two-columns cf ui-sortable section   " id="le_body_row_3" data-style="eyJlbGVtZW50SWQiOiJsZV9ib2R5X3Jvd18zIiwiYmFja2dyb3VuZEltYWdlIjoidXJsKGh0dHBzOi8vY29uY3JldGVnZW5pdXMuY2Evd3AtY29udGVudC91cGxvYWRzLzIwMTkvMDIvT3ZlcmhlYWQtMTctS29yb3ZhLUVhc3QucG5nKSIsImJhY2tncm91bmRQb3NpdGlvbiI6ImNlbnRlciIsImJhY2tncm91bmRJbWFnZUNvbG9yIjoiIiwiYmFja2dyb3VuZEltYWdlQ29sb3JPcGFjaXR5IjoiMCIsImJhY2tncm91bmRQYXJhbGF4IjpmYWxzZSwiYm9yZGVyVG9wV2lkdGgiOiIiLCJib3JkZXJUb3BDb2xvciI6IiIsImJvcmRlckJvdHRvbVdpZHRoIjoiIiwiYm9yZGVyQm90dG9tQ29sb3IiOiIiLCJzZWN0aW9uU2VwYXJhdG9yVHlwZSI6Im5vbmUiLCJzZWN0aW9uU2VwYXJhdG9yU3R5bGUiOiIiLCJleHRyYXMiOnsiYW5pbWF0aW9uRWZmZWN0IjoiIiwiYW5pbWF0aW9uRGVsYXkiOiIifSwicm93U2Nyb2xsRml4ZWRQb3NpdGlvbiI6Im5vbmUiLCJyb3dTY3JvbGxGaXhlZE1vYmlsZSI6ZmFsc2UsImFkZG9uIjp7InZpZGVvX2JhY2tncm91bmRfdHlwZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV93aWR0aCI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV9oZWlnaHQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF9tcDQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF93ZWJtIjoiIiwidmlkZW9fYmFja2dyb3VuZF91cmxfb2d2IjoiIiwidmlkZW9fYmFja2dyb3VuZF92ZXJ0aWNhbF9hbGlnbiI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9jb2xvciI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9vcGFjaXR5IjoiMCIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9pbWFnZSI6IiIsInZpZGVvX2JhY2tncm91bmRfaW1hZ2VfcG9zaXRpb24iOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX2FsdGVybmF0aXZlX2ltYWdlIjoiIn19"></div>
 <section class="test" style="background-image: url(test.jpg)">Test section</section>
+<figure class="test" style="background-image: url(test.jpg)">Test figure</figure>
 <span style="background-image: url(test.jpg)">Test span</span>
 <ul>
 	<li style="background-image: url(test.jpg)">Test li</li>

--- a/tests/Unit/fixtures/Image/bgimageslazyloaded.html
+++ b/tests/Unit/fixtures/Image/bgimageslazyloaded.html
@@ -68,7 +68,7 @@ img.emoji {
 <![endif]-->
 <link rel='https://api.w.org/' href='http://wordpress.test/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://wordpress.test/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://wordpress.test/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.0.3" />
 <meta name="generator" content="WooCommerce 3.5.4" />
 <link rel='shortlink' href='http://wordpress.test/?p=1147' />
@@ -105,6 +105,7 @@ img.emoji {
 <div data-bg="url(http://mega.wp-rocket.me/avada/wp-content/uploads/2014/11/review_bkgd321-compressor.jpg)" class="fusion-fullwidth fullwidth-box fusion-parallax-none nonhundred-percent-fullwidth non-hundred-percent-height-scrolling rocket-lazyload" style="background-color: #ffffff;background-position: center center;background-repeat: no-repeat;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover;"></div>
 <div data-bg="url(https://concretegenius.ca/wp-content/uploads/2019/02/Overhead-17-Korova-East.png)" style='background-repeat:no-repeat;background-position:center;background-attachment:;border-top-width:px;border-top-style:solid;border-top-color:;border-bottom-width:px;border-bottom-style:solid;border-bottom-color:;'  class="row two-columns cf ui-sortable section    rocket-lazyload" id="le_body_row_3" data-style="eyJlbGVtZW50SWQiOiJsZV9ib2R5X3Jvd18zIiwiYmFja2dyb3VuZEltYWdlIjoidXJsKGh0dHBzOi8vY29uY3JldGVnZW5pdXMuY2Evd3AtY29udGVudC91cGxvYWRzLzIwMTkvMDIvT3ZlcmhlYWQtMTctS29yb3ZhLUVhc3QucG5nKSIsImJhY2tncm91bmRQb3NpdGlvbiI6ImNlbnRlciIsImJhY2tncm91bmRJbWFnZUNvbG9yIjoiIiwiYmFja2dyb3VuZEltYWdlQ29sb3JPcGFjaXR5IjoiMCIsImJhY2tncm91bmRQYXJhbGF4IjpmYWxzZSwiYm9yZGVyVG9wV2lkdGgiOiIiLCJib3JkZXJUb3BDb2xvciI6IiIsImJvcmRlckJvdHRvbVdpZHRoIjoiIiwiYm9yZGVyQm90dG9tQ29sb3IiOiIiLCJzZWN0aW9uU2VwYXJhdG9yVHlwZSI6Im5vbmUiLCJzZWN0aW9uU2VwYXJhdG9yU3R5bGUiOiIiLCJleHRyYXMiOnsiYW5pbWF0aW9uRWZmZWN0IjoiIiwiYW5pbWF0aW9uRGVsYXkiOiIifSwicm93U2Nyb2xsRml4ZWRQb3NpdGlvbiI6Im5vbmUiLCJyb3dTY3JvbGxGaXhlZE1vYmlsZSI6ZmFsc2UsImFkZG9uIjp7InZpZGVvX2JhY2tncm91bmRfdHlwZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV93aWR0aCI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV9oZWlnaHQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF9tcDQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF93ZWJtIjoiIiwidmlkZW9fYmFja2dyb3VuZF91cmxfb2d2IjoiIiwidmlkZW9fYmFja2dyb3VuZF92ZXJ0aWNhbF9hbGlnbiI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9jb2xvciI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9vcGFjaXR5IjoiMCIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9pbWFnZSI6IiIsInZpZGVvX2JhY2tncm91bmRfaW1hZ2VfcG9zaXRpb24iOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX2FsdGVybmF0aXZlX2ltYWdlIjoiIn19"></div>
 <section data-bg="url(test.jpg)" class="test rocket-lazyload" style="">Test section</section>
+<figure data-bg="url(test.jpg)" class="test rocket-lazyload" style="">Test figure</figure>
 <span data-bg="url(test.jpg)" class="rocket-lazyload" style="">Test span</span>
 <ul>
 	<li data-bg="url(test.jpg)" class="rocket-lazyload" style="">Test li</li>


### PR DESCRIPTION
Closes WPR’s [#2570](https://github.com/wp-media/wp-rocket/issues/2570).