### PR TITLE
Include <a> tags when applying LazyLoad to background images

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -51,7 +51,7 @@ class Image {
 	 * @return string
 	 */
 	public function lazyloadBackgroundImages( $html, $buffer ) {
-		if ( ! preg_match_all( '#<(?<tag>div|figure|section|span|li)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER ) ) {
+		if ( ! preg_match_all( '#<(?<tag>div|figure|section|span|li|a)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER ) ) {
 			return $html;
 		}
 
@@ -98,7 +98,7 @@ class Image {
 			return str_replace( $class[0], $classes, $element );
 		}
 
-		return preg_replace( '#<(img|div|figure|section|li|span)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
+		return preg_replace( '#<(img|div|figure|section|li|span|a)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
 	}
 
 	/**

--- a/tests/Unit/fixtures/Image/bgimages.html
+++ b/tests/Unit/fixtures/Image/bgimages.html
@@ -112,5 +112,7 @@ img.emoji {
 	<li>Test li 2</li>
 </ul>
 <div class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"></div>
+<a href="#" style="background-image: url(test.jpg)">Test a</a>
+<a href="###">Without Background Image.</a>
 </body>
 </html>

--- a/tests/Unit/fixtures/Image/bgimageslazyloaded.html
+++ b/tests/Unit/fixtures/Image/bgimageslazyloaded.html
@@ -112,5 +112,7 @@ img.emoji {
 	<li>Test li 2</li>
 </ul>
 <div class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"></div>
+<a data-bg="url(test.jpg)" class="rocket-lazyload" href="#" style="">Test a</a>
+<a href="###">Without Background Image.</a>
 </body>
 </html>


### PR DESCRIPTION
Add anchor tags to elements that can be lazyloaded for background images.

- [x] Add `a` to regex for `lazyloadBackgroundImages`
- [x] Add `a` to regex for `addLazyClass`
- [x] Add two test cases to `bgimages`

Closes [Rocket issue 2660](https://github.com/wp-media/wp-rocket/issues/2660)