### PR TITLE
Adapt code to reflect lazyload script updates

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -39,18 +39,18 @@ class Assets {
 		];
 
 		$allowed_options = [
-			'container'       => 1,
-			'thresholds'      => 1,
-			'data_bg'         => 1,
-			'class_error'     => 1,
-			'load_delay'      => 1,
-			'auto_unobserve'  => 1,
-			'callback_enter'  => 1,
-			'callback_exit'   => 1,
-			'callback_reveal' => 1,
-			'callback_error'  => 1,
-			'callback_finish' => 1,
-			'use_native'      => 1,
+			'container'           => 1,
+			'thresholds'          => 1,
+			'data_bg'             => 1,
+			'class_error'         => 1,
+			'cancel_on_exit'      => 1,
+			'unobserve_completed' => 1,
+			'callback_enter'      => 1,
+			'callback_exit'       => 1,
+			'callback_loading'    => 1,
+			'callback_error'      => 1,
+			'callback_finish'     => 1,
+			'use_native'          => 1,
 		];
 
 		$args   = wp_parse_args( $args, $defaults );

--- a/src/Image.php
+++ b/src/Image.php
@@ -72,7 +72,7 @@ class Image {
 
 			$lazy_bg = $this->addLazyCLass( $element[0] );
 			$lazy_bg = str_replace( $url[0], '', $lazy_bg );
-			$lazy_bg = str_replace( '<' . $element['tag'], '<' . $element['tag'] . ' data-bg="url(' . esc_attr( $url['url'] ) . ')"', $lazy_bg );
+			$lazy_bg = str_replace( '<' . $element['tag'], '<' . $element['tag'] . ' data-bg="' . esc_attr( $url['url'] ) . '"', $lazy_bg );
 
 			$html = str_replace( $element[0], $lazy_bg, $html );
 			unset( $lazy_bg );

--- a/tests/Unit/Image/TestLazyloadBackgroundImages.php
+++ b/tests/Unit/Image/TestLazyloadBackgroundImages.php
@@ -1,60 +1,32 @@
 <?php
-/**
- * Unit tests for RocketLazyload\Image::lazyloadBackgroundImages method
- *
- * @package RocketLazyload
- */
 
 namespace RocketLazyload\Tests\Unit\Image;
 
-use PHPUnit\Framework\TestCase;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
 use RocketLazyload\Image;
 
 /**
- * Tests for the RocketLazyload\Image::lazyloadBackgroundImages method
+ * @covers RocketLazyload\Image::lazyloadBackgroundImages
  *
- * @coversDefaultClass RocketLazyload\Image
+ * @group Image
  */
-class TestLazyloadBackgroundImages extends TestCase
-{
-    /**
-     * Instance of Image
-     *
-     * @var Image
-     */
+class TestLazyloadBackgroundImages extends TestCase {
     private $image;
 
-    /**
-     * Do this before each test
-     *
-     * @return void
-     */
-    public function setUp()
-    {
+    public function setUp() {
         parent::setUp();
         Monkey\setUp();
         $this->image = new Image();
     }
 
-    /**
-     * Do this after each test
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
+    public function tearDown() {
         Monkey\tearDown();
         parent::tearDown();
     }
 
-    /**
-     * @covers ::lazyloadBackgroundImages
-     * @author Remy Perona
-     */
-    public function testShouldReturnSameWhenNoBackgroundImage()
-    {
+    public function testShouldReturnSameWhenNoBackgroundImage() {
         $noimage = \file_get_contents( RLL_COMMON_TESTS_ROOT . '/fixtures/Image/noimage.html');
 
         $this->assertSame(
@@ -63,12 +35,7 @@ class TestLazyloadBackgroundImages extends TestCase
         );
     }
 
-    /**
-     * @covers ::lazyloadBackgroundImages
-     * @author Remy Perona
-     */
-    public function testShouldReturnBackgroundImagesLazyloaded()
-    {
+    public function testShouldReturnBackgroundImagesLazyloaded() {
         Functions\when('esc_attr')->returnArg();
 
         $original = \file_get_contents( RLL_COMMON_TESTS_ROOT . '/fixtures/Image/bgimages.html');

--- a/tests/Unit/fixtures/Image/bgimageslazyloaded.html
+++ b/tests/Unit/fixtures/Image/bgimageslazyloaded.html
@@ -93,26 +93,26 @@ img.emoji {
 <meta name="msapplication-TileImage" content="http://wordpress.test/wp-content/uploads/2017/01/cropped-bridsmade4-270x270.jpg" />
 </head>
 <body class="page-template-default page page-id-1147 logged-in admin-bar no-customize-support woocommerce-no-js">
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
-<div data-bg="url(test.jpg)" class="test rocket-lazyload" style=""></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style=""></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style    =   ''></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" style=' color:#000'></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" data-test="bla" style=' color:#000'></div>
-<div data-bg="url(test.jpg)" class="rocket-lazyload" data-test="bla" style="color:#000; " data-toto="tata"></div>
-<div data-bg="url(http://mega.wp-rocket.me/avada/wp-content/uploads/2014/11/review_bkgd321-compressor.jpg)" class="fusion-fullwidth fullwidth-box fusion-parallax-none nonhundred-percent-fullwidth non-hundred-percent-height-scrolling rocket-lazyload" style="background-color: #ffffff;background-position: center center;background-repeat: no-repeat;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover;"></div>
-<div data-bg="url(https://concretegenius.ca/wp-content/uploads/2019/02/Overhead-17-Korova-East.png)" style='background-repeat:no-repeat;background-position:center;background-attachment:;border-top-width:px;border-top-style:solid;border-top-color:;border-bottom-width:px;border-bottom-style:solid;border-bottom-color:;'  class="row two-columns cf ui-sortable section    rocket-lazyload" id="le_body_row_3" data-style="eyJlbGVtZW50SWQiOiJsZV9ib2R5X3Jvd18zIiwiYmFja2dyb3VuZEltYWdlIjoidXJsKGh0dHBzOi8vY29uY3JldGVnZW5pdXMuY2Evd3AtY29udGVudC91cGxvYWRzLzIwMTkvMDIvT3ZlcmhlYWQtMTctS29yb3ZhLUVhc3QucG5nKSIsImJhY2tncm91bmRQb3NpdGlvbiI6ImNlbnRlciIsImJhY2tncm91bmRJbWFnZUNvbG9yIjoiIiwiYmFja2dyb3VuZEltYWdlQ29sb3JPcGFjaXR5IjoiMCIsImJhY2tncm91bmRQYXJhbGF4IjpmYWxzZSwiYm9yZGVyVG9wV2lkdGgiOiIiLCJib3JkZXJUb3BDb2xvciI6IiIsImJvcmRlckJvdHRvbVdpZHRoIjoiIiwiYm9yZGVyQm90dG9tQ29sb3IiOiIiLCJzZWN0aW9uU2VwYXJhdG9yVHlwZSI6Im5vbmUiLCJzZWN0aW9uU2VwYXJhdG9yU3R5bGUiOiIiLCJleHRyYXMiOnsiYW5pbWF0aW9uRWZmZWN0IjoiIiwiYW5pbWF0aW9uRGVsYXkiOiIifSwicm93U2Nyb2xsRml4ZWRQb3NpdGlvbiI6Im5vbmUiLCJyb3dTY3JvbGxGaXhlZE1vYmlsZSI6ZmFsc2UsImFkZG9uIjp7InZpZGVvX2JhY2tncm91bmRfdHlwZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV93aWR0aCI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV9oZWlnaHQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF9tcDQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF93ZWJtIjoiIiwidmlkZW9fYmFja2dyb3VuZF91cmxfb2d2IjoiIiwidmlkZW9fYmFja2dyb3VuZF92ZXJ0aWNhbF9hbGlnbiI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9jb2xvciI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9vcGFjaXR5IjoiMCIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9pbWFnZSI6IiIsInZpZGVvX2JhY2tncm91bmRfaW1hZ2VfcG9zaXRpb24iOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX2FsdGVybmF0aXZlX2ltYWdlIjoiIn19"></div>
-<section data-bg="url(test.jpg)" class="test rocket-lazyload" style="">Test section</section>
-<figure data-bg="url(test.jpg)" class="test rocket-lazyload" style="">Test figure</figure>
-<span data-bg="url(test.jpg)" class="rocket-lazyload" style="">Test span</span>
+<div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
+<div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
+<div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
+<div data-bg="test.jpg" class="test rocket-lazyload" style=""></div>
+<div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
+<div data-bg="test.jpg" class="rocket-lazyload" style    =   ''></div>
+<div data-bg="test.jpg" class="rocket-lazyload" style=' color:#000'></div>
+<div data-bg="test.jpg" class="rocket-lazyload" data-test="bla" style=' color:#000'></div>
+<div data-bg="test.jpg" class="rocket-lazyload" data-test="bla" style="color:#000; " data-toto="tata"></div>
+<div data-bg="http://mega.wp-rocket.me/avada/wp-content/uploads/2014/11/review_bkgd321-compressor.jpg" class="fusion-fullwidth fullwidth-box fusion-parallax-none nonhundred-percent-fullwidth non-hundred-percent-height-scrolling rocket-lazyload" style="background-color: #ffffff;background-position: center center;background-repeat: no-repeat;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover;"></div>
+<div data-bg="https://concretegenius.ca/wp-content/uploads/2019/02/Overhead-17-Korova-East.png" style='background-repeat:no-repeat;background-position:center;background-attachment:;border-top-width:px;border-top-style:solid;border-top-color:;border-bottom-width:px;border-bottom-style:solid;border-bottom-color:;'  class="row two-columns cf ui-sortable section    rocket-lazyload" id="le_body_row_3" data-style="eyJlbGVtZW50SWQiOiJsZV9ib2R5X3Jvd18zIiwiYmFja2dyb3VuZEltYWdlIjoidXJsKGh0dHBzOi8vY29uY3JldGVnZW5pdXMuY2Evd3AtY29udGVudC91cGxvYWRzLzIwMTkvMDIvT3ZlcmhlYWQtMTctS29yb3ZhLUVhc3QucG5nKSIsImJhY2tncm91bmRQb3NpdGlvbiI6ImNlbnRlciIsImJhY2tncm91bmRJbWFnZUNvbG9yIjoiIiwiYmFja2dyb3VuZEltYWdlQ29sb3JPcGFjaXR5IjoiMCIsImJhY2tncm91bmRQYXJhbGF4IjpmYWxzZSwiYm9yZGVyVG9wV2lkdGgiOiIiLCJib3JkZXJUb3BDb2xvciI6IiIsImJvcmRlckJvdHRvbVdpZHRoIjoiIiwiYm9yZGVyQm90dG9tQ29sb3IiOiIiLCJzZWN0aW9uU2VwYXJhdG9yVHlwZSI6Im5vbmUiLCJzZWN0aW9uU2VwYXJhdG9yU3R5bGUiOiIiLCJleHRyYXMiOnsiYW5pbWF0aW9uRWZmZWN0IjoiIiwiYW5pbWF0aW9uRGVsYXkiOiIifSwicm93U2Nyb2xsRml4ZWRQb3NpdGlvbiI6Im5vbmUiLCJyb3dTY3JvbGxGaXhlZE1vYmlsZSI6ZmFsc2UsImFkZG9uIjp7InZpZGVvX2JhY2tncm91bmRfdHlwZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZSI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV93aWR0aCI6IiIsInZpZGVvX2JhY2tncm91bmRfeW91dHViZV9oZWlnaHQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF9tcDQiOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX3VybF93ZWJtIjoiIiwidmlkZW9fYmFja2dyb3VuZF91cmxfb2d2IjoiIiwidmlkZW9fYmFja2dyb3VuZF92ZXJ0aWNhbF9hbGlnbiI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9jb2xvciI6IiIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9vcGFjaXR5IjoiMCIsInZpZGVvX2JhY2tncm91bmRfb3ZlcmxheV9pbWFnZSI6IiIsInZpZGVvX2JhY2tncm91bmRfaW1hZ2VfcG9zaXRpb24iOiIiLCJ2aWRlb19iYWNrZ3JvdW5kX2FsdGVybmF0aXZlX2ltYWdlIjoiIn19"></div>
+<section data-bg="test.jpg" class="test rocket-lazyload" style="">Test section</section>
+<figure data-bg="test.jpg" class="test rocket-lazyload" style="">Test figure</figure>
+<span data-bg="test.jpg" class="rocket-lazyload" style="">Test span</span>
 <ul>
-	<li data-bg="url(test.jpg)" class="rocket-lazyload" style="">Test li</li>
+	<li data-bg="test.jpg" class="rocket-lazyload" style="">Test li</li>
 	<li>Test li 2</li>
 </ul>
 <div class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"></div>
-<a data-bg="url(test.jpg)" class="rocket-lazyload" href="#" style="">Test a</a>
+<a data-bg="test.jpg" class="rocket-lazyload" href="#" style="">Test a</a>
 <a href="###">Without Background Image.</a>
 </body>
 </html>


### PR DESCRIPTION
Updating the version of the lazyload script we use introduced some breaking change, mainly related to lazyload for background images.

This PR fixes this issue, and also reflects any breaking change noted on: https://github.com/verlok/vanilla-lazyload/blob/master/UPGRADE.md

This is required for WP Rocket 3.6.