### PR TITLE
Fix #2704 Add <noscript> tags for lazyloaded <picture>

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -153,7 +153,7 @@ class Image {
 
 			$img_lazy  = $this->replaceImage( $img );
 			$img_lazy .= $this->noscript( $img[0] );
-            $html = preg_replace('#<noscript[^>]*>.*'.$img[0].'.*<\/noscript>(*SKIP)(*FAIL)|'.$img[0].'#iUs', $img_lazy, $html);
+			$html      = preg_replace( '#<noscript[^>]*>.*' . $img[0] . '.*<\/noscript>(*SKIP)(*FAIL)|' . $img[0] . '#iUs', $img_lazy, $html );
 
 			unset( $img_lazy );
 		}

--- a/src/Image.php
+++ b/src/Image.php
@@ -21,7 +21,7 @@ class Image {
 	 */
 	public function lazyloadImages( $html, $buffer ) {
 		$clean_buffer = preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
-		$clean_buffer = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $html );
+		$clean_buffer = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $clean_buffer );
 		if (! preg_match_all('#<img(?<atts>\s.+)\s?/?>#iUs', $clean_buffer, $images, PREG_SET_ORDER)) {
 			return $html;
 		}
@@ -153,7 +153,7 @@ class Image {
 
 			$img_lazy  = $this->replaceImage( $img );
 			$img_lazy .= $this->noscript( $img[0] );
-			$html      = str_replace( $img[0], $img_lazy, $html );
+            $html = preg_replace('#<noscript[^>]*>.*'.$img[0].'.*<\/noscript>(*SKIP)(*FAIL)|'.$img[0].'#iUs', $img_lazy, $html);
 
 			unset( $img_lazy );
 		}

--- a/src/Image.php
+++ b/src/Image.php
@@ -20,7 +20,9 @@ class Image {
 	 * @return string
 	 */
 	public function lazyloadImages( $html, $buffer ) {
-		if ( ! preg_match_all( '#<img(?<atts>\s.+)\s?/?>#iUs', $buffer, $images, PREG_SET_ORDER ) ) {
+		$clean_buffer = preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
+		$clean_buffer = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $html );
+		if (! preg_match_all('#<img(?<atts>\s.+)\s?/?>#iUs', $clean_buffer, $images, PREG_SET_ORDER)) {
 			return $html;
 		}
 
@@ -149,8 +151,9 @@ class Image {
 				continue;
 			}
 
-			$img_lazy = $this->replaceImage( $img );
-			$html     = str_replace( $img[0], $img_lazy, $html );
+			$img_lazy  = $this->replaceImage( $img );
+			$img_lazy .= $this->noscript( $img[0] );
+			$html      = str_replace( $img[0], $img_lazy, $html );
 
 			unset( $img_lazy );
 		}

--- a/tests/Unit/fixtures/Image/pictureslazyloaded.html
+++ b/tests/Unit/fixtures/Image/pictureslazyloaded.html
@@ -214,7 +214,7 @@ img.emoji {
 
 
 
-<div class="wp-block-image"><figure class="alignleft"><picture class="test"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" media="(max-width: 150px)"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1-80x80.jpg" media="(max-width: 80px)"><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 150x150" class="wp-image-904" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" /></picture></figure></div>
+<div class="wp-block-image"><figure class="alignleft"><picture class="test"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" media="(max-width: 150px)"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1-80x80.jpg" media="(max-width: 80px)"><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 150x150" class="wp-image-904" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" /><noscript><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" alt="Image Alignment 150x150" class="wp-image-904" /></noscript></picture></figure></div>
 
 
 
@@ -258,7 +258,7 @@ img.emoji {
 
 
 
-<div class="wp-block-image size-full wp-image-904"><figure class="alignleft"><picture><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 150x150" class="wp-image-904" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" /></picture><figcaption> tou&#8217;p&#8217;tite légende.</figcaption></figure></div>
+<div class="wp-block-image size-full wp-image-904"><figure class="alignleft"><picture><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 150x150" class="wp-image-904" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" /><noscript><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" alt="Image Alignment 150x150" class="wp-image-904" /></noscript></picture><figcaption> tou&#8217;p&#8217;tite légende.</figcaption></figure></div>
 
 
 
@@ -278,7 +278,7 @@ img.emoji {
 
 
 
-<div class="wp-block-image size-full wp-image-905"><figure class="alignright"><picture><source data-lazy-srcset="" media=""><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 300x200" class="wp-image-905" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" /></picture><figcaption> Trop bien vu, cet alignement à droite.</figcaption></figure></div>
+<div class="wp-block-image size-full wp-image-905"><figure class="alignright"><picture><source data-lazy-srcset="" media=""><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 300x200" class="wp-image-905" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" /><noscript><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" alt="Image Alignment 300x200" class="wp-image-905" /></noscript></picture><figcaption> Trop bien vu, cet alignement à droite.</figcaption></figure></div>
 
 
 


### PR DESCRIPTION
For Rocket's issue https://github.com/wp-media/wp-rocket/issues/2704.

Added missing <noscript> tag for lazyloaded pictures.

To Do @engahmeds3ed 
- [x] - Unit tests
- [x] - Integration tests