### PR TITLE
Missing trim in Image::addLazyloadClass

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -90,7 +90,7 @@ class Image {
 	private function addLazyClass( $element ) {
 		if ( preg_match( '#class=["\']?(?<classes>[^"\'>]*)["\']?#is', $element, $class ) ) {
 			$classes = trim( $class['classes'] );
-			if ( empty( $class['classes'] ) ) {
+			if ( empty( $classes ) ) {
 				return str_replace( $class[0], 'class="rocket-lazyload"', $element );
 			}
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -89,6 +89,7 @@ class Image {
 	 */
 	private function addLazyClass( $element ) {
 		if ( preg_match( '#class=["\']?(?<classes>[^"\'>]*)["\']?#is', $element, $class ) ) {
+			$classes = trim( $class['classes'] );
 			if ( empty( $class['classes'] ) ) {
 				return str_replace( $class[0], 'class="rocket-lazyload"', $element );
 			}

--- a/tests/Unit/fixtures/Image/bgimages.html
+++ b/tests/Unit/fixtures/Image/bgimages.html
@@ -114,5 +114,6 @@ img.emoji {
 <div class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"></div>
 <a href="#" style="background-image: url(test.jpg)">Test a</a>
 <a href="###">Without Background Image.</a>
+<a class=" " id="empty_class_test" href="#" style="background-image: url(test.jpg)">Test a</a>
 </body>
 </html>

--- a/tests/Unit/fixtures/Image/bgimageslazyloaded.html
+++ b/tests/Unit/fixtures/Image/bgimageslazyloaded.html
@@ -114,5 +114,6 @@ img.emoji {
 <div class="avia-bg-style-fixed" style="background-image:url(example.jpg)" data-section-bg="repeat"></div>
 <a data-bg="test.jpg" class="rocket-lazyload" href="#" style="">Test a</a>
 <a href="###">Without Background Image.</a>
+<a data-bg="test.jpg" class="rocket-lazyload" id="empty_class_test" href="#" style="">Test a</a>
 </body>
 </html>


### PR DESCRIPTION
**Reproduce the issue** ✅ 
Identified the issue on my localhost.

**Identify the root cause** ✅ 
https://github.com/wp-media/rocket-lazyload-common/blob/fde493535ca389882484327af32c99c839d2527f/src/Image.php#L92

**Scope a solution** ✅ 
Check if trimmed $class['classes'] is empty in order to add the `class="rocket-lazyload"`
Something like should do the trick:
```
$classes = trim( $class['classes'] );
 if (empty($classes)) {
```

**Effort** ✅ 
Effort `[S]` 