### PR TITLE
Fixes 78 layout breaks when pictures <img> alternative attribute has quotes or any html encoded characters

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -289,8 +289,6 @@ class Image {
 			$safe_img = str_replace('/', '\/', preg_quote( $img[0], '#' ));
 			$html      = preg_replace( '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#iU', $img_lazy, $html );
 
-			echo '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#iU'."\n\n";
-
 			unset( $img_lazy );
 		}
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -286,8 +286,10 @@ class Image {
 
 			$img_lazy  = $this->replaceImage( $img );
 			$img_lazy .= $this->noscript( $img[0] );
-			$safe_img = str_replace('/', '\/', preg_quote( $img[0] ));
+			$safe_img = str_replace('/', '\/', preg_quote( $img[0], '#' ));
 			$html      = preg_replace( '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#iU', $img_lazy, $html );
+
+			echo '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#iU'."\n\n";
 
 			unset( $img_lazy );
 		}

--- a/src/Image.php
+++ b/src/Image.php
@@ -286,7 +286,8 @@ class Image {
 
 			$img_lazy  = $this->replaceImage( $img );
 			$img_lazy .= $this->noscript( $img[0] );
-			$html      = preg_replace( '#<noscript[^>]*>.*' . $img[0] . '.*<\/noscript>(*SKIP)(*FAIL)|' . $img[0] . '#iUs', $img_lazy, $html );
+			$safe_img = str_replace('/', '\/', preg_quote( $img[0] ));
+			$html      = preg_replace( '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#iU', $img_lazy, $html );
 
 			unset( $img_lazy );
 		}

--- a/tests/Unit/fixtures/Image/pictures.html
+++ b/tests/Unit/fixtures/Image/pictures.html
@@ -216,7 +216,12 @@ img.emoji {
 
 <div class="wp-block-image"><figure class="alignleft"><picture class="test"><source srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" media="(max-width: 150px)"><source srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1-80x80.jpg" media="(max-width: 80px)"><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" alt="Image Alignment 150x150" class="wp-image-904" /></picture></figure></div>
 
-
+			<picture class="responsive-featured-image">
+				<source media="(max-width: 1152px)" sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-512x300.jpg 512w">
+				<source media="(max-width: 800px)" sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-800x300.jpg 800w">
+				<source sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-928x300.jpg 1240w">
+				<img alt="Random Non-Sequiturs &#038; Photography" itemprop="url" src="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-421x300.jpg" />
+			</picture>
 
 <p>Le reste de ce paragraphe est du simple remplissage pour voir le texte se disposer autour de l&#8217;image de 150 x 150, qui reste <strong><em>alignée à gauche</em></strong>.</p>
 

--- a/tests/Unit/fixtures/Image/pictureslazyloaded.html
+++ b/tests/Unit/fixtures/Image/pictureslazyloaded.html
@@ -216,7 +216,12 @@ img.emoji {
 
 <div class="wp-block-image"><figure class="alignleft"><picture class="test"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" media="(max-width: 150px)"><source data-lazy-srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1-80x80.jpg" media="(max-width: 80px)"><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 150x150" class="wp-image-904" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" /><noscript><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-150x150-1.jpg" alt="Image Alignment 150x150" class="wp-image-904" /></noscript></picture></figure></div>
 
-
+			<picture class="responsive-featured-image">
+				<source media="(max-width: 1152px)" sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" data-lazy-srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-512x300.jpg 512w">
+				<source media="(max-width: 800px)" sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" data-lazy-srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-800x300.jpg 800w">
+				<source sizes="(max-width: 800px) 100vw,(max-width: 1152px) 100vw, 1240px" data-lazy-srcset="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-928x300.jpg 1240w">
+				<img alt="Random Non-Sequiturs &#038; Photography" itemprop="url" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" data-lazy-src="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-421x300.jpg" /><noscript><img alt="Random Non-Sequiturs &#038; Photography" itemprop="url" src="https://example.org/wp-content/files15/2020/07/OperaHouseSliderImage06162019-421x300.jpg" /></noscript>
+			</picture>
 
 <p>Le reste de ce paragraphe est du simple remplissage pour voir le texte se disposer autour de l&#8217;image de 150 x 150, qui reste <strong><em>alignée à gauche</em></strong>.</p>
 


### PR DESCRIPTION
Cherry-picked commits from PR #80. Why? Needs to base off of `master` to get the latest changes.

Closes #78

skip img tag parsing inside preg_replace and and use preg_quote for that