### PR TITLE
Fix <noscript> filtering

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -21,7 +21,7 @@ class Image {
 	 */
 	public function lazyloadImages( $html, $buffer ) {
 		$clean_buffer = preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
-		$clean_buffer = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $clean_buffer );
+		$clean_buffer = preg_replace( '/<noscript>(?:.+)?<\/noscript>/Umsi', '', $clean_buffer );
 		if (! preg_match_all('#<img(?<atts>\s.+)\s?/?>#iUs', $clean_buffer, $images, PREG_SET_ORDER)) {
 			return $html;
 		}


### PR DESCRIPTION
Lazyloading wasn't working on a clients site before this change was made, seems to be more inline with the preg_match line above also?