### PR TITLE
Fix PHP notice when picture element doesn't contain any source tags

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -256,10 +256,10 @@ class Image {
 				continue;
 			}
 
+			$lazy_sources = 0;
+
 			if ( preg_match_all( '#<source(?<atts>\s.+)>#iUs', $picture['sources'], $sources, PREG_SET_ORDER ) ) {
 				$sources = array_unique( $sources, SORT_REGULAR );
-
-				$lazy_sources = 0;
 
 				foreach ( $sources as $source ) {
 					$lazyload_srcset = preg_replace( '/([\s"\'])srcset/i', '\1data-lazy-srcset', $source[0] );


### PR DESCRIPTION
https://github.com/wp-media/wp-rocket/issues/3056

as @Tabrisrp said
> We should initialize the $lazy_sources variable before the loop instead, with a default value of 0.