### PR TITLE
Fixes wp-rocket/#3437 Prevent lazyload of <img> inside an excluded <picture>

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -253,25 +253,30 @@ class Image {
 
 		foreach ( $pictures as $picture ) {
 			if ( $this->isExcluded( $picture[0], $excluded ) ) {
+				$nolazy_picture = str_replace( '<img', '<img data-skip-lazy=""', $picture[0] );
+				$html           = str_replace( $picture[0], $nolazy_picture, $html );
+
 				continue;
 			}
 
-			$lazy_sources = 0;
-
 			if ( preg_match_all( '#<source(?<atts>\s.+)>#iUs', $picture['sources'], $sources, PREG_SET_ORDER ) ) {
-				$sources = array_unique( $sources, SORT_REGULAR );
+				$lazy_sources = 0;
+				$sources      = array_unique( $sources, SORT_REGULAR );
+				$lazy_picture = $picture[0];
 
 				foreach ( $sources as $source ) {
 					$lazyload_srcset = preg_replace( '/([\s"\'])srcset/i', '\1data-lazy-srcset', $source[0] );
-					$html            = str_replace( $source[0], $lazyload_srcset, $html );
+					$lazy_picture    = str_replace( $source[0], $lazyload_srcset, $lazy_picture );
 
 					unset( $lazyload_srcset );
 					$lazy_sources++;
 				}
-			}
 
-			if ( 0 === $lazy_sources ) {
-				continue;
+				if ( 0 === $lazy_sources ) {
+					continue;
+				}
+
+				$html = str_replace( $picture[0], $lazy_picture, $html );
 			}
 
 			if ( ! preg_match( '#<img(?<atts>\s.+)\s?/?>#iUs', $picture[0], $img ) ) {

--- a/tests/Unit/fixtures/Image/pictures.html
+++ b/tests/Unit/fixtures/Image/pictures.html
@@ -300,9 +300,6 @@ img.emoji {
 
 <p>Et voilà jeune Jack Sparrow ! Vous avez survécu aux eaux tumultueuses de l&#8217;alignement. Vous pouvez passer au prochain test !</p>
 
-
-
-
 <figure><iframe src="https://www.youtube.com/embed/FeK9cq2lCvU" allowfullscreen="allowfullscreen" width="560" height="315"></iframe></figure>
                         <a class="post-edit-link" href="http://wordpress.test/wp-admin/post.php?post=1147&#038;action=edit">Edit This</a>        </div>
     </article>

--- a/tests/Unit/fixtures/Image/pictures.html
+++ b/tests/Unit/fixtures/Image/pictures.html
@@ -285,7 +285,10 @@ img.emoji {
 
 <div class="wp-block-image size-full wp-image-905"><figure class="alignright"><picture><source srcset="" media=""><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" alt="Image Alignment 300x200" class="wp-image-905" /></picture><figcaption> Trop bien vu, cet alignement à droite.</figcaption></figure></div>
 
-
+<picture data-skip-lazy="">
+	<source srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" media="(max-width: 580px)">
+	<img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" alt="Image Alignment 580x300" class="wp-image-906" />
+</picture>
 
 <p>Et maintenant tribord toute avec un alignement&nbsp;<em>à droite.</em>À nouveau il devrait y avoir suffisament d&#8217;espace au-dessus, en-dessous et à gauche de l&#8217;image. Ça semble tout bon tout ça. Et ne laissez personne vous dire le contraire.</p>
 
@@ -296,6 +299,7 @@ img.emoji {
 
 
 <p>Et voilà jeune Jack Sparrow ! Vous avez survécu aux eaux tumultueuses de l&#8217;alignement. Vous pouvez passer au prochain test !</p>
+
 
 
 

--- a/tests/Unit/fixtures/Image/pictureslazyloaded.html
+++ b/tests/Unit/fixtures/Image/pictureslazyloaded.html
@@ -255,7 +255,7 @@ img.emoji {
 
 
 
-<figure class="wp-block-image"><picture><source data-no-lazy="1" srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" media="(max-width: 580px)"><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" alt="Image Alignment 580x300" class="wp-image-906" /></picture></figure>
+<figure class="wp-block-image"><picture><source data-no-lazy="1" srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" media="(max-width: 580px)"><img data-skip-lazy="" src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" alt="Image Alignment 580x300" class="wp-image-906" /></picture></figure>
 
 
 
@@ -285,7 +285,10 @@ img.emoji {
 
 <div class="wp-block-image size-full wp-image-905"><figure class="alignright"><picture><source data-lazy-srcset="" media=""><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%200%200'%3E%3C/svg%3E" alt="Image Alignment 300x200" class="wp-image-905" data-lazy-src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" /><noscript><img src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-300x200-1.jpg" alt="Image Alignment 300x200" class="wp-image-905" /></noscript></picture><figcaption> Trop bien vu, cet alignement à droite.</figcaption></figure></div>
 
-
+<picture data-skip-lazy="">
+	<source srcset="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" media="(max-width: 580px)">
+	<img data-skip-lazy="" src="http://wordpress.test/wp-content/uploads/2013/03/image-alignement-580x300-1.jpg" alt="Image Alignment 580x300" class="wp-image-906" />
+</picture>
 
 <p>Et maintenant tribord toute avec un alignement&nbsp;<em>à droite.</em>À nouveau il devrait y avoir suffisament d&#8217;espace au-dessus, en-dessous et à gauche de l&#8217;image. Ça semble tout bon tout ça. Et ne laissez personne vous dire le contraire.</p>
 
@@ -296,6 +299,7 @@ img.emoji {
 
 
 <p>Et voilà jeune Jack Sparrow ! Vous avez survécu aux eaux tumultueuses de l&#8217;alignement. Vous pouvez passer au prochain test !</p>
+
 
 
 

--- a/tests/Unit/fixtures/Image/pictureslazyloaded.html
+++ b/tests/Unit/fixtures/Image/pictureslazyloaded.html
@@ -300,9 +300,6 @@ img.emoji {
 
 <p>Et voilà jeune Jack Sparrow ! Vous avez survécu aux eaux tumultueuses de l&#8217;alignement. Vous pouvez passer au prochain test !</p>
 
-
-
-
 <figure><iframe src="https://www.youtube.com/embed/FeK9cq2lCvU" allowfullscreen="allowfullscreen" width="560" height="315"></iframe></figure>
                         <a class="post-edit-link" href="http://wordpress.test/wp-admin/post.php?post=1147&#038;action=edit">Edit This</a>        </div>
     </article>


### PR DESCRIPTION
## Description

This PR adds the `data-skip-lazy` attribute to `img` inside a `picture`, when the picture is excluded from lazyload.

It also fixes a bug that would set the `data-lazy-srcset` on `source` when it should not.

Fixes https://github.com/wp-media/wp-rocket/issues/3437

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests updated to validate the code update

## Is there any change compared to the proposed solution during grooming?

Yes, the proposed solution was to ignore `picture` elements in the html when doing the lazyload for images, by changing the buffer value.

I took a different approach, to propose a self-contained solution, where we directly add an excluded attribute to the `img` inside a `picture`. That way, this `img` will be skipped by the lazyload for images.

It also avoids modifying the buffer, which can have unexpected side-effects.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes