### PR TITLE
Filter empty values before using the array

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -373,6 +373,8 @@ class Image {
 			$excluded_values = (array) $excluded_values;
 		}
 
+		$excluded_values = array_filter( $excluded_values );
+
 		if ( empty( $excluded_values ) ) {
 			return false;
 		}


### PR DESCRIPTION
# Description

## Documentation

### User documentation

Prevent PHP warning when using `strpos()` with empty value

### Technical documentation

Use `array_filter()` to remove empty values from the excluded values array

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.