### PR TITLE
Use typed filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         }
     },
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "wp-media/apply-filters-typed": "^1.0"
     },
     "require-dev": {
         "php": ">=7.0",

--- a/src/Image.php
+++ b/src/Image.php
@@ -542,9 +542,9 @@ class Image {
 	/**
 	 * Checks if the noscript tag is enabled
 	 *
-	 * @return bool
+	 * @return mixed
 	 */
-	private function noscriptEnabled(): bool {
+	private function noscriptEnabled() {
 		/**
 		 * Filter to enable or disable noscript tag
 		 *

--- a/src/Image.php
+++ b/src/Image.php
@@ -550,7 +550,7 @@ class Image {
 		 *
 		 * @param bool $enable_noscript Enable or disable noscript tag.
 		 */
-		return apply_filters( 'rocket_lazyload_noscript', true );
+		return wpm_apply_filters_typed( 'boolean', 'rocket_lazyload_noscript', true );
 	}
 
 	/**
@@ -614,7 +614,7 @@ class Image {
 
 		$stop = count( $textarr );// loop stuff.
 
-		// Ignore proessing of specific tags.
+		// Ignore processing of specific tags.
 		$tags_to_ignore       = 'code|pre|style|script|textarea';
 		$ignore_block_element = '';
 


### PR DESCRIPTION
# Description

## Documentation

### User documentation
Prevent error in case of filter returning a value which is not a boolean

### Technical documentation

Use `wp-media/apply-filters-typed` library to handle the strict typing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
`wp-media/apply-filters-typed` library


# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
