### PR TITLE
Enhancemnet: Add aside to lazyload background images

### DIFF
--- a/Tests/Fixtures/image/bgimages.html
+++ b/Tests/Fixtures/image/bgimages.html
@@ -94,6 +94,7 @@ img.emoji {
 </head>
 <body class="page-template-default page page-id-1147 logged-in admin-bar no-customize-support woocommerce-no-js">
 <div style="background-image: url(test.jpg)"></div>
+<aside style="background-image: url(test_image.jpg)"></aside>
 <div style="background-image   :    url(   test.jpg   )   "></div>
 <div style="background-image:url(test.jpg)"></div>
 <div class="test" style="background-image:url('test.jpg')"></div>

--- a/Tests/Fixtures/image/bgimageslazyloaded.html
+++ b/Tests/Fixtures/image/bgimageslazyloaded.html
@@ -94,6 +94,7 @@ img.emoji {
 </head>
 <body class="page-template-default page page-id-1147 logged-in admin-bar no-customize-support woocommerce-no-js">
 <div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
+<aside data-bg="test_image.jpg" class="rocket-lazyload" style=""></aside>
 <div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
 <div data-bg="test.jpg" class="rocket-lazyload" style=""></div>
 <div data-bg="test.jpg" class="test rocket-lazyload" style=""></div>

--- a/src/Image.php
+++ b/src/Image.php
@@ -67,7 +67,7 @@ class Image {
 	 * @return string
 	 */
 	public function lazyloadBackgroundImages( $html, $buffer ) {
-		if ( ! preg_match_all( '#<(?<tag>div|figure|section|span|li|a)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER ) ) {
+		if ( ! preg_match_all( '#<(?<tag>div|figure|section|aside|span|li|a)\s+(?<before>[^>]+[\'"\s])?style\s*=\s*([\'"])(?<styles>.*?)\3(?<after>[^>]*)>#is', $buffer, $elements, PREG_SET_ORDER ) ) {
 			return $html;
 		}
 
@@ -132,7 +132,7 @@ class Image {
 		$class = $this->getClasses( $element );
 
 		if ( ! $class ) {
-			$result = preg_replace( '#<(img|div|figure|section|li|span|a)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
+			$result = preg_replace( '#<(img|div|figure|section|aside|li|span|a)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
 
 			if ( ! $result ) {
 				return $element;


### PR DESCRIPTION
# Description
This PR add aside tag to lazyload background images.

Fixes https://github.com/wp-media/wp-rocket/issues/7115

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).


## Detailed scenario
Check [here](https://github.com/wp-media/wp-rocket/issues/7115) for detailed scenario

## Technical description

### Documentation
Add `aside` to lazyload background images.


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
