### PR TITLE
Add install SVN to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 

--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -35,6 +35,9 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 


### PR DESCRIPTION
# Description

New version of Ubuntu used in GH actions images doesn't have SVN installed by default. This PR fixes the issue in workflows requiring WP installation by installing SVN during the steps.

## Type of change
- [x] Chore

## Detailed scenario

- Nothing to test

## Technical description

### Documentation

Install SVN in workflow