### PR TITLE
Escape image data-lazy-src attribute

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -40,7 +40,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/lint_phpcs.yml
+++ b/.github/workflows/lint_phpcs.yml
@@ -19,7 +19,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2' ]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
         wp-versions: ['latest']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.

--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/test_legacy.yml
+++ b/.github/workflows/test_legacy.yml
@@ -52,7 +52,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/src/Image.php
+++ b/src/Image.php
@@ -523,7 +523,7 @@ class Image {
 				$height = absint( $atts['height'] );
 			}
 
-			// Only match src attributes with safe values (no spaces, quotes, or angle brackets)
+			// Only match src attributes with safe values (no spaces, quotes, or angle brackets).
 			$placeholder_atts = preg_replace(
 				'@\ssrc\s*=\s*(\'|")(?<src>[^\s"\'>]+)\1@iUs',
 				' src="' . $this->getPlaceholder( $width, $height ) . '"',

--- a/src/Image.php
+++ b/src/Image.php
@@ -529,7 +529,7 @@ class Image {
 				' src="' . $this->getPlaceholder( $width, $height ) . '"',
 				$image['atts']
 			);
-			
+
 			$image_lazyload = str_replace(
 				$image['atts'],
 				$placeholder_atts . ' data-lazy-src="' . esc_url( $image['src'] ) . '"',

--- a/src/Image.php
+++ b/src/Image.php
@@ -523,9 +523,18 @@ class Image {
 				$height = absint( $atts['height'] );
 			}
 
-			$placeholder_atts = preg_replace( '@\ssrc\s*=\s*(\'|")(?<src>.*)\1@iUs', ' src="' . $this->getPlaceholder( $width, $height ) . '"', $image['atts'] );
-
-			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image_lazyload );
+			// Only match src attributes with safe values (no spaces, quotes, or angle brackets)
+			$placeholder_atts = preg_replace(
+				'@\ssrc\s*=\s*(\'|")(?<src>[^\s"\'>]+)\1@iUs',
+				' src="' . $this->getPlaceholder( $width, $height ) . '"',
+				$image['atts']
+			);
+			
+			$image_lazyload = str_replace(
+				$image['atts'],
+				$placeholder_atts . ' data-lazy-src="' . esc_url( $image['src'] ) . '"',
+				$image_lazyload
+			);
 
 			if ( preg_match( $native_pattern, $image_lazyload ) ) {
 				$result = preg_replace( $native_pattern, '', $image_lazyload );


### PR DESCRIPTION
# Description

Updated regex to match 'src' attributes with safe values and modified lazy loading logic.

Related to:
- https://github.com/wp-media/wp-rocket.me/issues/5250

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

Escapes the `data-lazy-src` attribute in the lazy loaded image tag.

### How to test

Follow original issue for more details.


## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

Test if images are still lazyloaded

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
